### PR TITLE
Fix monospaced font breaking symbols alignment

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -138,7 +138,7 @@ input[type="number"],
 .cm-s-obsidian span.cm-formatting-task,
 .cm-s-obsidian span.cm-formatting-list,
 .cm-s-obsidian span.cm-formatting-quote {
-	font-family: var(--font-monospace);
+	font-family: var(--quattro-font);
 }
 
 input[type="text"], 


### PR DESCRIPTION
before:

<img width="573" src="https://user-images.githubusercontent.com/6603389/110966503-9a5a4c80-8355-11eb-95a1-064c06c22bf8.png">

after:

<img width="572" src="https://user-images.githubusercontent.com/6603389/110966539-a34b1e00-8355-11eb-8140-c55d7e7bc620.png">
