### PR TITLE
swap top and bottom margins for h2

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -372,8 +372,8 @@ input[type="number"] {
 .markdown-preview-view h2 {
 	font-size: 16px;
 	line-height: 24px;
-	margin-bottom: 30px; 
-	margin-top: 10px;
+	margin-bottom: 10px; 
+	margin-top: 30px;
 }
 
 .markdown-preview-view h3,


### PR DESCRIPTION
To my eyes the top and bottom margin for h2 preview should be swapped

### Before:
![CleanShot 2021-03-21 at 14 30 46](https://user-images.githubusercontent.com/198502/111906704-38cf6780-8a52-11eb-87bd-22dafb7b164e.png)

### After:
![CleanShot 2021-03-21 at 14 31 35](https://user-images.githubusercontent.com/198502/111906708-3f5ddf00-8a52-11eb-99a1-7db06dcfe51d.png)
