### PR TITLE
Change the color of the cursor in Vim mode

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -779,3 +779,9 @@ input[type="number"] {
 .markdown-preview-view ul > li.task-list-item {
 	margin-left: 0;
 }
+
+/* Vim mode cursor */
+.cm-fat-cursor .CodeMirror-cursor {
+	background-color: var(--text-accent);
+	opacity: 0.7;
+}


### PR DESCRIPTION
Before:

<img width="196" alt="Screenshot 2021-04-27 at 13 42 53" src="https://user-images.githubusercontent.com/63876/116235750-867c7580-a75e-11eb-91d6-8cd4e353dc00.png">


After:

<img width="236" alt="Screenshot 2021-04-27 at 13 37 08" src="https://user-images.githubusercontent.com/63876/116235599-5b922180-a75e-11eb-9598-9b9496ba247e.png">
<img width="214" alt="Screenshot 2021-04-27 at 13 36 56" src="https://user-images.githubusercontent.com/63876/116235602-5c2ab800-a75e-11eb-984a-4bfe44ba864a.png">
