### PR TITLE
Unlock header font size

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -134,7 +134,7 @@ body,
 .markdown-preview-view h5,
 .markdown-preview-view h6,
 .markdown-preview-view code {
-    font-size: 16px;
+    font-size: 1em !important;
     line-height: 26px;
 }
 


### PR DESCRIPTION
- change h1-h6 `font-size` to `1em`
- allow header font size to shift with the rest of text when zooming in/out with trackpad/appearance menu font size slider
- add `!important` to make the change appear in Obsidian