### PR TITLE
Add partial Kanban support

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -862,7 +862,6 @@ input[type="number"] {
 .kanban-plugin__grow-wrap>textarea:focus {
     font-family: var(--quattro-font);
     display: flex;
-    overflow: scroll;
 }
 
 /* set lane title color */

--- a/obsidian.css
+++ b/obsidian.css
@@ -890,11 +890,16 @@ body .kanban-plugin__lane {
     border:var(--background-primary);
 }
 
-/* make text and wrapper the same color */
+/* make wrapper and background the same color */
 .kanban-plugin__markdown-preview-view>div>*:first-child,
 .kanban-plugin__markdown-preview-view>div>*:last-child {
     margin-top: 0;
     background-color: var(--background-primary) !important;
+}
+.kanban-plugin__markdown-preview-view>div>* {
+    overflow-x: auto;
+    overflow-wrap: break-word;
+    background-color: var(--background-primary);
 }
 .kanban-plugin__markdown-preview-view:not(>div>*:last-child) {
     background-color: var(--background-primary) !important;

--- a/obsidian.css
+++ b/obsidian.css
@@ -851,3 +851,51 @@ input[type="number"] {
     background-color: var(--text-accent);
     opacity: 0.7;
 }
+
+/* Kanban Support */
+
+/* UI/preview font */
+.kanban-plugin__markdown-preview-view {
+    font-family: var(--quattro-font) !important;
+}
+/* editor font */
+.kanban-plugin__grow-wrap>textarea:focus {
+    font-family: var(--quattro-font);
+    display: flex;
+    overflow: scroll;
+}
+
+/* set lane title color */
+.kanban-plugin__markdown-preview-view>div>.frontmatter-container {
+    background-color: var(--background-primary) !important;
+}
+.kanban-plugin__grow-wrap>textarea, .kanban-plugin__grow-wrap:after {
+    border: 1px solid var(--background-modifier-border);
+    padding: 5px 7px;
+    font: inherit;
+    line-height: 1.5;
+    grid-area: 1 / 1 / 2 / 2;
+    font-size: .875rem;
+    overflow: hidden;
+    overflow-wrap: break-word;
+    white-space: pre-wrap;
+    background-color: var(--background-primary);
+    font-family: var(--quattro-font);
+}
+
+/* set lane color */
+body .kanban-plugin__lane {
+    background:transparent;
+    padding:0;
+    border:var(--background-primary);
+}
+
+/* make text and wrapper the same color */
+.kanban-plugin__markdown-preview-view>div>*:first-child,
+.kanban-plugin__markdown-preview-view>div>*:last-child {
+    margin-top: 0;
+    background-color: var(--background-primary) !important;
+}
+.kanban-plugin__markdown-preview-view:not(>div>*:last-child) {
+    background-color: var(--background-primary) !important;
+}

--- a/obsidian.css
+++ b/obsidian.css
@@ -601,7 +601,7 @@ input[type="number"] {
 }
 
 .view-header-title {
-    font-size: 13px;
+    font-size: 1em;
     color: var(--text-faint);
     line-height: 30px;
 }
@@ -852,7 +852,7 @@ input[type="number"] {
     opacity: 0.7;
 }
 
-/* Kanban Support */
+/* Kanban Plugin */
 
 /* UI/preview font */
 .kanban-plugin__markdown-preview-view {
@@ -902,4 +902,7 @@ body .kanban-plugin__lane {
 }
 .kanban-plugin__markdown-preview-view:not(>div>*:last-child) {
     background-color: var(--background-primary) !important;
+}
+body .kanban-plugin__markdown-preview-view, body .kanban-plugin__grow-wrap > textarea, body .kanban-plugin__grow-wrap::after, body .kanban-plugin__item-title p {
+    background-color: var(--background-primary);
 }


### PR DESCRIPTION
- Add Kanban support by fixing the color of Kanban lanes and cards
  - Previously: background color of lane titles and items didn't match
    properly
  - Now: `first-child`, `last-child` and lane titles are set to
    `background-primary`.
